### PR TITLE
Fix double call to FindClass

### DIFF
--- a/heapster.cc
+++ b/heapster.cc
@@ -266,7 +266,6 @@ class Heapster {
         (void*)&Heapster::JNI_SetSamplingPeriod }
     };
 
-    klass = env->FindClass(HELPER_CLASS);
     if ((klass = env->FindClass(HELPER_CLASS)) == NULL)
       errx(3, "Failed to find the heapster helper class (%s)\n", HELPER_CLASS);
 


### PR DESCRIPTION
VM->FindClass was mistakenly getting called twice in VMStart.
